### PR TITLE
SpecularLighting param error

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,9 +590,9 @@ new SVG.OffsetEffect(x, y);
 [W3 doc](https://www.w3.org/TR/SVG/filters.html#feSpecularLightingElement)
 
 ```javascript
-filter.specularLighting(surfaceScale, diffuseConstant, specularExponent, kernelUnitLength);
+filter.specularLighting(surfaceScale, specularConstant, specularExponent, kernelUnitLength);
 //or
-new SVG.SpecularLightingEffect(surfaceScale, diffuseConstant, specularExponent, kernelUnitLength);
+new SVG.SpecularLightingEffect(surfaceScale, specularConstant, specularExponent, kernelUnitLength);
 ```
 
 ***very complicated, just check out the W3 doc***

--- a/src/svg.filter.js
+++ b/src/svg.filter.js
@@ -83,8 +83,8 @@
         return this.put(new SVG.DisplacementMapEffect(in1,in2,scale,xChannelSelector,yChannelSelector))
       },
       // SpecularLighting effect
-      specularLighting: function(surfaceScale,diffuseConstant,specularExponent,kernelUnitLength){
-        return this.put(new SVG.SpecularLightingEffect(surfaceScale,diffuseConstant,specularExponent,kernelUnitLength))
+      specularLighting: function(surfaceScale,specularConstant,specularExponent,kernelUnitLength){
+        return this.put(new SVG.SpecularLightingEffect(surfaceScale,specularConstant,specularExponent,kernelUnitLength))
       },
       // Tile effect
       tile: function(){
@@ -248,8 +248,8 @@
       return this.parent() && this.parent().displacementMap(this,in2,scale,xChannelSelector,yChannelSelector) //pass this as the first input
     },
     // SpecularLighting effect
-    specularLighting: function(surfaceScale,diffuseConstant,specularExponent,kernelUnitLength){
-      return this.parent() && this.parent().specularLighting(surfaceScale,diffuseConstant,specularExponent,kernelUnitLength).in(this)
+    specularLighting: function(surfaceScale,specularConstant,specularExponent,kernelUnitLength){
+      return this.parent() && this.parent().specularLighting(surfaceScale,specularConstant,specularExponent,kernelUnitLength).in(this)
     },
     // Tile effect
     tile: function(){
@@ -426,10 +426,10 @@
         kernelUnitLength: kernelUnitLength
       })
     },
-    specularLighting: function(surfaceScale,diffuseConstant,specularExponent,kernelUnitLength){
+    specularLighting: function(surfaceScale,specularConstant,specularExponent,kernelUnitLength){
       this.attr({
         surfaceScale: surfaceScale,
-        diffuseConstant: diffuseConstant,
+        specularConstant: specularConstant,
         specularExponent: specularExponent,
         kernelUnitLength: kernelUnitLength
       })


### PR DESCRIPTION
SpecularLighting uses a parameter "diffuseConstant" both in the readme
and the src code. It should be "specularConstant" according to W3C (and
InkScape).