### PR TITLE
fix component transfer child attributes

### DIFF
--- a/src/svg.filter.js
+++ b/src/svg.filter.js
@@ -265,6 +265,11 @@ filterChildNodes.forEach((child) => {
   Filter[name] = class extends Effect {
     constructor (node) {
       super(nodeOrNew('fe' + name, node), node)
+      if (node) {
+        for (const key in node) {
+          this.attr(key, node[key])
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
Attributes for the componentTransfer filter were not set. This is a way to fix it.