### PR TITLE
Update svg.filter.js.d.ts

### DIFF
--- a/svg.filter.js.d.ts
+++ b/svg.filter.js.d.ts
@@ -106,7 +106,7 @@ declare module "@svgdotjs/svg.js" {
   }
 
   interface LightEffects {
-    distandLight (attr?: Object | SVGFEDistantLightElement): DistantLight
+    distantLight (attr?: Object | SVGFEDistantLightElement): DistantLight
     pointLight (attr?: Object | SVGFEPointLightElement): PointLight
     spotLight (attr?: Object | SVGFESpotLightElement): SpotLight
   }
@@ -153,7 +153,7 @@ declare module "@svgdotjs/svg.js" {
     constructor (node: SVGFEDiffuseLightingElement)
     constructor (attr: Object)
 
-    distandLight (attr?: Object | SVGFEDistantLightElement): DistantLight
+    distantLight (attr?: Object | SVGFEDistantLightElement): DistantLight
     pointLight (attr?: Object | SVGFEPointLightElement): PointLight
     spotLight (attr?: Object | SVGFESpotLightElement): SpotLight
   }
@@ -207,7 +207,7 @@ declare module "@svgdotjs/svg.js" {
     constructor (node: SVGFESpecularLightingElement)
     constructor (attr: Object)
 
-    distandLight (attr?: Object | SVGFEDistantLightElement): DistantLight
+    distantLight (attr?: Object | SVGFEDistantLightElement): DistantLight
     pointLight (attr?: Object | SVGFEPointLightElement): PointLight
     spotLight (attr?: Object | SVGFESpotLightElement): SpotLight
   }


### PR DESCRIPTION
Correcting typo of "distandLight" to "distantLight" in type definitions, per discussion in Issue #61