### PR TITLE
dropShadow updates

### DIFF
--- a/src/svg.filter.js
+++ b/src/svg.filter.js
@@ -118,7 +118,7 @@ const updateFunctions = {
   // DisplacementMap effect
   displacementMap: getAttrSetter(['in', 'in2', 'scale', 'xChannelSelector', 'yChannelSelector']),
   // DropShadow effect
-  dropShadow: getAttrSetter(['in', 'dx', 'dy', 'stdDeviation']),
+  dropShadow: getAttrSetter(['in', 'dx', 'dy', 'stdDeviation', 'flood-color', 'flood-opacity']),
   // Flood effect
   flood: getAttrSetter(['flood-color', 'flood-opacity']),
   // Gaussian Blur effect
@@ -378,9 +378,9 @@ const chainingEffects = {
   displacementMap: function (in2, scale, xChannelSelector, yChannelSelector) {
     return this.parent() && this.parent().displacementMap(this, in2, scale, xChannelSelector, yChannelSelector) // pass this as the first input
   },
-  // DisplacementMap effect
-  dropShadow: function (x, y, stdDeviation) {
-    return this.parent() && this.parent().dropShadow(this, x, y, stdDeviation).in(this) // pass this as the first input
+  // DropShadow effect
+  dropShadow: function (x, y, stdDeviation, color, opacity) {
+    return this.parent() && this.parent().dropShadow(this, x, y, stdDeviation, color, opacity).in(this) // pass this as the first input
   },
   // Flood effect
   flood: function (color, opacity) {

--- a/svg.filter.js.d.ts
+++ b/svg.filter.js.d.ts
@@ -95,7 +95,7 @@ declare module "@svgdotjs/svg.js" {
     convolveMatrix (matrix: Array<number> | string): ConvolveMatrixEffect
     diffuseLighting (surfaceScale: number, lightingColor: string, diffuseConstant: number, kernelUnitLength: number): DiffuseLightingEffect
     displacementMap (in2: EffectOrString, scale: number, xChannelSelector: string, yChannelSelector: string): DisplacementMapEffect
-    dropShadow (in2: EffectOrString, dx: number, dy: number, stdDeviation: number, color: string, opacity: number): DropShadowEffect
+    dropShadow (dx: number, dy: number, stdDeviation: number, color: string, opacity: number): DropShadowEffect
     flood (color: string, opacity: number): FloodEffect
     gaussianBlur (x: number, y: number): GaussianBlurEffect
     image (src: string): ImageEffect

--- a/svg.filter.js.d.ts
+++ b/svg.filter.js.d.ts
@@ -32,7 +32,7 @@ declare module "@svgdotjs/svg.js" {
     convolveMatrix (matrix: Array<number> | string): ConvolveMatrixEffect
     diffuseLighting (surfaceScale: number, lightingColor: string, diffuseConstant: number, kernelUnitLength: number): DiffuseLightingEffect
     displacementMap (in1: EffectOrString, in2: EffectOrString, scale: number, xChannelSelector: string, yChannelSelector: string): DisplacementMapEffect
-    dropShadow (in1: EffectOrString, dx: number, dy: number, stdDeviation: number): DropShadowEffect
+    dropShadow (in1: EffectOrString, dx: number, dy: number, stdDeviation: number, color: string, opacity: number): DropShadowEffect
     flood (color: string, opacity: number): FloodEffect
     gaussianBlur (x: number, y: number): GaussianBlurEffect
     image (src: string): ImageEffect
@@ -50,6 +50,8 @@ declare module "@svgdotjs/svg.js" {
     readonly dy: SVGAnimatedNumber;
     readonly stdDeviationX: SVGAnimatedNumber;
     readonly stdDeviationY: SVGAnimatedNumber;
+    readonly color: SVGAnimatedString;
+    readonly opacity: SVGAnimatedNumber;
     setStdDeviation(stdDeviationX: number, stdDeviationY: number): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDisplacementMapElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -93,7 +95,7 @@ declare module "@svgdotjs/svg.js" {
     convolveMatrix (matrix: Array<number> | string): ConvolveMatrixEffect
     diffuseLighting (surfaceScale: number, lightingColor: string, diffuseConstant: number, kernelUnitLength: number): DiffuseLightingEffect
     displacementMap (in2: EffectOrString, scale: number, xChannelSelector: string, yChannelSelector: string): DisplacementMapEffect
-    dropShadow (dx: number, dy: number, stdDeviation: number): DropShadowEffect
+    dropShadow (in2: EffectOrString, dx: number, dy: number, stdDeviation: number, color: string, opacity: number): DropShadowEffect
     flood (color: string, opacity: number): FloodEffect
     gaussianBlur (x: number, y: number): GaussianBlurEffect
     image (src: string): ImageEffect


### PR DESCRIPTION
Updates dropShadow to support flood-color and flood-opacity attributes, per side discussion in Issue #63.

The thing I'm not sure about is on Line 53 of 
svg.filter.js.d.ts - should color: be SVGAnimatedString ? Or something different.